### PR TITLE
feat: add structured object support for Capacities

### DIFF
--- a/readwise_twos_sync/capacities_client.py
+++ b/readwise_twos_sync/capacities_client.py
@@ -1,7 +1,7 @@
 """Capacities API client."""
 
 import requests
-from typing import List, Dict
+from typing import List, Dict, Optional
 from datetime import datetime
 import logging
 
@@ -11,29 +11,105 @@ logger = logging.getLogger(__name__)
 class CapacitiesClient:
     """Client for interacting with the Capacities API."""
 
-    API_URL_TEMPLATE = "https://api.capacities.io/spaces/{space_id}/blocks"
+    API_URL_TEMPLATE = "https://api.capacities.io/spaces/{space_id}/objects"
+    SPACE_INFO_URL = "https://api.capacities.io/spaces/{space_id}/space-info"
 
-    def __init__(self, token: str, space_id: str):
+    def __init__(
+        self,
+        token: str,
+        space_id: str,
+        structure_id: Optional[str] = None,
+        property_definition_ids: Optional[Dict[str, str]] = None,
+    ):
         """Initialize Capacities client.
 
         Args:
             token: Capacities API token
             space_id: Capacities space identifier
+            structure_id: Optional Capacities structure identifier
+            property_definition_ids: Optional mapping of property names to definition IDs
         """
         self.token = token
         self.space_id = space_id
+        self.structure_id = structure_id
+        self.property_definition_ids = property_definition_ids or {}
         self.headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
 
-    def post_highlights(self, highlights: List[Dict], books: Dict[int, Dict[str, str]]):
+    def _fetch_space_info(self) -> Dict:
+        """Fetch space information including structures and property definitions."""
+        url = self.SPACE_INFO_URL.format(space_id=self.space_id)
+        response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
+        return response.json()
+
+    def _ensure_structure_and_properties(
+        self,
+        structure_id: Optional[str],
+        property_definition_ids: Optional[Dict[str, str]],
+    ) -> (str, Dict[str, str]):
+        """Ensure structure ID and property IDs are available.
+
+        Fetches space info if either value is missing.
+        """
+
+        structure_id = structure_id or self.structure_id
+        property_definition_ids = property_definition_ids or self.property_definition_ids
+
+        if structure_id and property_definition_ids:
+            return structure_id, property_definition_ids
+
+        info = self._fetch_space_info()
+
+        if not structure_id:
+            structures = info.get("structures", [])
+            structure_id = next(
+                (s.get("id") for s in structures if s.get("name") == "RootPage"),
+                structures[0]["id"] if structures else None,
+            )
+
+        if not property_definition_ids:
+            property_definition_ids = {
+                pd.get("name"): pd.get("id")
+                for pd in info.get("propertyDefinitions", [])
+            }
+
+        return structure_id, property_definition_ids
+
+    def post_highlights(
+        self,
+        highlights: List[Dict],
+        books: Dict[int, Dict[str, str]],
+        structure_id: Optional[str] = None,
+        property_definition_ids: Optional[Dict[str, str]] = None,
+    ):
         """Post highlights to Capacities."""
+
+        structure_id, property_definition_ids = self._ensure_structure_and_properties(
+            structure_id, property_definition_ids
+        )
+
         url = self.API_URL_TEMPLATE.format(space_id=self.space_id)
         today_title = datetime.now().strftime("%Y-%m-%d")
 
+        def _build_properties(text: str, title: Optional[str] = None, author: Optional[str] = None) -> Dict[str, str]:
+            properties: Dict[str, str] = {}
+            text_id = property_definition_ids.get("text")
+            if text_id:
+                properties[text_id] = text
+            title_id = property_definition_ids.get("title")
+            if title_id and title:
+                properties[title_id] = title
+            author_id = property_definition_ids.get("author")
+            if author_id and author:
+                properties[author_id] = author
+            return properties
+
         if not highlights:
-            payload = {"content": f"No new highlights for {today_title}"}
+            properties = _build_properties(f"No new highlights for {today_title}")
+            payload = {"structureId": structure_id, "properties": properties}
             try:
                 response = requests.post(url, headers=self.headers, json=payload)
                 response.raise_for_status()
@@ -55,11 +131,11 @@ class CapacitiesClient:
                     logger.warning(f"No book metadata found for book ID {book_id}")
                     continue
 
-                title = book_meta["title"]
-                author = book_meta["author"]
-                note_text = f"{title}, {author}: {text}"
+                title = book_meta.get("title")
+                author = book_meta.get("author")
 
-                payload = {"content": note_text.strip()}
+                properties = _build_properties(text, title, author)
+                payload = {"structureId": structure_id, "properties": properties}
                 response = requests.post(url, headers=self.headers, json=payload)
                 response.raise_for_status()
                 successful_posts += 1

--- a/tests/test_capacities_client.py
+++ b/tests/test_capacities_client.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import patch, Mock
+
+from readwise_twos_sync.capacities_client import CapacitiesClient
+
+
+def test_post_highlights_with_structure_and_properties():
+    """Ensure highlights are posted with structure and properties."""
+    client = CapacitiesClient(
+        token="token",
+        space_id="space",
+        structure_id="root123",
+        property_definition_ids={"text": "textProp", "title": "titleProp", "author": "authorProp"},
+    )
+
+    highlights = [{"book_id": 1, "text": "Quote"}]
+    books = {1: {"title": "Book", "author": "Author"}}
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+
+    with patch("readwise_twos_sync.capacities_client.requests.post", return_value=mock_response) as mock_post:
+        client.post_highlights(highlights, books)
+
+        mock_post.assert_called_once()
+        url = mock_post.call_args[0][0]
+        assert url == "https://api.capacities.io/spaces/space/objects"
+        payload = mock_post.call_args[1]["json"]
+        assert payload["structureId"] == "root123"
+        props = payload["properties"]
+        assert props["textProp"] == "Quote"
+        assert props["titleProp"] == "Book"
+        assert props["authorProp"] == "Author"
+
+
+def test_post_highlights_fetches_space_info_when_missing():
+    """Client fetches structure and property IDs when not provided."""
+    client = CapacitiesClient(token="token", space_id="space")
+
+    highlights = [{"book_id": 1, "text": "Quote"}]
+    books = {1: {"title": "Book", "author": "Author"}}
+
+    mock_post_response = Mock()
+    mock_post_response.raise_for_status.return_value = None
+
+    mock_get_response = Mock()
+    mock_get_response.raise_for_status.return_value = None
+    mock_get_response.json.return_value = {
+        "structures": [{"id": "root123", "name": "RootPage"}],
+        "propertyDefinitions": [
+            {"id": "textProp", "name": "text"},
+            {"id": "titleProp", "name": "title"},
+            {"id": "authorProp", "name": "author"},
+        ],
+    }
+
+    with patch("readwise_twos_sync.capacities_client.requests.get", return_value=mock_get_response) as mock_get, \
+        patch("readwise_twos_sync.capacities_client.requests.post", return_value=mock_post_response) as mock_post:
+        client.post_highlights(highlights, books)
+
+        mock_get.assert_called_once()
+        mock_post.assert_called_once()
+        payload = mock_post.call_args[1]["json"]
+        assert payload["structureId"] == "root123"
+        props = payload["properties"]
+        assert props["textProp"] == "Quote"
+        assert props["titleProp"] == "Book"
+        assert props["authorProp"] == "Author"


### PR DESCRIPTION
## Summary
- switch Capacities client to `/objects` endpoint
- support structureId and property definition IDs, auto-fetching via `/space-info`
- send highlights as Capacities objects with structured properties
- add unit tests for Capacities client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68967ef940c88332ab785b0763781951