### PR TITLE
Use Capacities daily-note API

### DIFF
--- a/readwise_twos_sync/capacities_client.py
+++ b/readwise_twos_sync/capacities_client.py
@@ -1,9 +1,10 @@
 """Capacities API client."""
 
-import requests
-from typing import List, Dict, Optional
-from datetime import datetime
 import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -11,72 +12,21 @@ logger = logging.getLogger(__name__)
 class CapacitiesClient:
     """Client for interacting with the Capacities API."""
 
-    API_URL_TEMPLATE = "https://api.capacities.io/spaces/{space_id}/objects"
-    SPACE_INFO_URL = "https://api.capacities.io/spaces/{space_id}/space-info"
+    SAVE_DAILY_NOTE_URL = "https://api.capacities.io/save-to-daily-note"
 
-    def __init__(
-        self,
-        token: str,
-        space_id: str,
-        structure_id: Optional[str] = None,
-        property_definition_ids: Optional[Dict[str, str]] = None,
-    ):
+    def __init__(self, token: str, space_id: str):
         """Initialize Capacities client.
 
         Args:
             token: Capacities API token
             space_id: Capacities space identifier
-            structure_id: Optional Capacities structure identifier
-            property_definition_ids: Optional mapping of property names to definition IDs
         """
         self.token = token
         self.space_id = space_id
-        self.structure_id = structure_id
-        self.property_definition_ids = property_definition_ids or {}
         self.headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
         }
-
-    def _fetch_space_info(self) -> Dict:
-        """Fetch space information including structures and property definitions."""
-        url = self.SPACE_INFO_URL.format(space_id=self.space_id)
-        response = requests.get(url, headers=self.headers)
-        response.raise_for_status()
-        return response.json()
-
-    def _ensure_structure_and_properties(
-        self,
-        structure_id: Optional[str],
-        property_definition_ids: Optional[Dict[str, str]],
-    ) -> (str, Dict[str, str]):
-        """Ensure structure ID and property IDs are available.
-
-        Fetches space info if either value is missing.
-        """
-
-        structure_id = structure_id or self.structure_id
-        property_definition_ids = property_definition_ids or self.property_definition_ids
-
-        if structure_id and property_definition_ids:
-            return structure_id, property_definition_ids
-
-        info = self._fetch_space_info()
-
-        if not structure_id:
-            structures = info.get("structures", [])
-            structure_id = next(
-                (s.get("id") for s in structures if s.get("name") == "RootPage"),
-                structures[0]["id"] if structures else None,
-            )
-
-        if not property_definition_ids:
-            property_definition_ids = {
-                pd.get("name"): pd.get("id")
-                for pd in info.get("propertyDefinitions", [])
-            }
-
-        return structure_id, property_definition_ids
 
     def post_highlights(
         self,
@@ -85,65 +35,33 @@ class CapacitiesClient:
         structure_id: Optional[str] = None,
         property_definition_ids: Optional[Dict[str, str]] = None,
     ):
-        """Post highlights to Capacities."""
+        """Post highlights to today's daily note in Capacities."""
 
-        structure_id, property_definition_ids = self._ensure_structure_and_properties(
-            structure_id, property_definition_ids
-        )
-
-        url = self.API_URL_TEMPLATE.format(space_id=self.space_id)
         today_title = datetime.now().strftime("%Y-%m-%d")
 
-        def _build_properties(text: str, title: Optional[str] = None, author: Optional[str] = None) -> Dict[str, str]:
-            properties: Dict[str, str] = {}
-            text_id = property_definition_ids.get("text")
-            if text_id:
-                properties[text_id] = text
-            title_id = property_definition_ids.get("title")
-            if title_id and title:
-                properties[title_id] = title
-            author_id = property_definition_ids.get("author")
-            if author_id and author:
-                properties[author_id] = author
-            return properties
-
         if not highlights:
-            properties = _build_properties(f"No new highlights for {today_title}")
-            payload = {"structureId": structure_id, "properties": properties}
-            try:
-                response = requests.post(url, headers=self.headers, json=payload)
-                response.raise_for_status()
-                logger.info("Posted 'no highlights' message to Capacities")
-            except requests.RequestException as e:
-                logger.error(f"Failed to post no-highlights message to Capacities: {e}")
-            return
-
-        successful_posts = 0
-        failed_posts = 0
-
-        for highlight in highlights:
-            try:
+            md_text = f"No new highlights for {today_title}"
+        else:
+            lines = []
+            for highlight in highlights:
+                text = highlight.get("text", "")
                 book_id = highlight.get("book_id")
-                text = highlight.get("text")
-                book_meta = books.get(book_id)
-
-                if not book_meta:
-                    logger.warning(f"No book metadata found for book ID {book_id}")
-                    continue
-
+                book_meta = books.get(book_id, {})
                 title = book_meta.get("title")
                 author = book_meta.get("author")
+                meta_parts = [part for part in [title, author] if part]
+                meta = " — " + ", ".join(meta_parts) if meta_parts else ""
+                lines.append(f"- {text}{meta}")
+            md_text = "\n".join(lines)
 
-                properties = _build_properties(text, title, author)
-                payload = {"structureId": structure_id, "properties": properties}
-                response = requests.post(url, headers=self.headers, json=payload)
-                response.raise_for_status()
-                successful_posts += 1
-            except requests.RequestException as e:
-                logger.error(f"Failed to post highlight to Capacities: {e}")
-                failed_posts += 1
+        payload = {"spaceId": self.space_id, "mdText": md_text}
 
-        logger.info(f"Posted {successful_posts} highlights to Capacities")
-        if failed_posts:
-            logger.warning(f"Failed to post {failed_posts} highlights")
+        try:
+            response = requests.post(
+                self.SAVE_DAILY_NOTE_URL, headers=self.headers, json=payload
+            )
+            response.raise_for_status()
+            logger.info("Posted highlights to Capacities daily note")
+        except requests.RequestException as e:
+            logger.error(f"Failed to post highlights to Capacities: {e}")
 

--- a/tests/test_capacities_client.py
+++ b/tests/test_capacities_client.py
@@ -1,17 +1,11 @@
-import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
+from datetime import datetime
 
 from readwise_twos_sync.capacities_client import CapacitiesClient
 
 
-def test_post_highlights_with_structure_and_properties():
-    """Ensure highlights are posted with structure and properties."""
-    client = CapacitiesClient(
-        token="token",
-        space_id="space",
-        structure_id="root123",
-        property_definition_ids={"text": "textProp", "title": "titleProp", "author": "authorProp"},
-    )
+def test_post_highlights_sends_markdown():
+    client = CapacitiesClient(token="token", space_id="space")
 
     highlights = [{"book_id": 1, "text": "Quote"}]
     books = {1: {"title": "Book", "author": "Author"}}
@@ -24,45 +18,23 @@ def test_post_highlights_with_structure_and_properties():
 
         mock_post.assert_called_once()
         url = mock_post.call_args[0][0]
-        assert url == "https://api.capacities.io/spaces/space/objects"
+        assert url == "https://api.capacities.io/save-to-daily-note"
         payload = mock_post.call_args[1]["json"]
-        assert payload["structureId"] == "root123"
-        props = payload["properties"]
-        assert props["textProp"] == "Quote"
-        assert props["titleProp"] == "Book"
-        assert props["authorProp"] == "Author"
+        assert payload["spaceId"] == "space"
+        assert payload["mdText"] == "- Quote — Book, Author"
 
 
-def test_post_highlights_fetches_space_info_when_missing():
-    """Client fetches structure and property IDs when not provided."""
+def test_post_highlights_handles_empty_list():
     client = CapacitiesClient(token="token", space_id="space")
 
-    highlights = [{"book_id": 1, "text": "Quote"}]
-    books = {1: {"title": "Book", "author": "Author"}}
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
 
-    mock_post_response = Mock()
-    mock_post_response.raise_for_status.return_value = None
+    with patch("readwise_twos_sync.capacities_client.requests.post", return_value=mock_response) as mock_post:
+        client.post_highlights([], {})
 
-    mock_get_response = Mock()
-    mock_get_response.raise_for_status.return_value = None
-    mock_get_response.json.return_value = {
-        "structures": [{"id": "root123", "name": "RootPage"}],
-        "propertyDefinitions": [
-            {"id": "textProp", "name": "text"},
-            {"id": "titleProp", "name": "title"},
-            {"id": "authorProp", "name": "author"},
-        ],
-    }
-
-    with patch("readwise_twos_sync.capacities_client.requests.get", return_value=mock_get_response) as mock_get, \
-        patch("readwise_twos_sync.capacities_client.requests.post", return_value=mock_post_response) as mock_post:
-        client.post_highlights(highlights, books)
-
-        mock_get.assert_called_once()
         mock_post.assert_called_once()
         payload = mock_post.call_args[1]["json"]
-        assert payload["structureId"] == "root123"
-        props = payload["properties"]
-        assert props["textProp"] == "Quote"
-        assert props["titleProp"] == "Book"
-        assert props["authorProp"] == "Author"
+        assert payload["spaceId"] == "space"
+        today = datetime.now().strftime("%Y-%m-%d")
+        assert payload["mdText"] == f"No new highlights for {today}"


### PR DESCRIPTION
## Summary
- post highlights to Capacities via the /save-to-daily-note endpoint
- generate simple markdown bullets for highlights or a no-highlights notice
- test daily-note posting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689681439c1083329b376d883f0bf60e