### PR TITLE
feat: capture capacities metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ READWISE_TOKEN=your_readwise_token_here
 TWOS_USER_ID=your_twos_user_id_here
 TWOS_TOKEN=your_twos_api_token_here
 
+# Capacities API Credentials (optional)
+# Get these from your Capacities workspace
+CAPACITIES_SPACE_ID=your_capacities_space_id_here
+CAPACITIES_TOKEN=your_capacities_token_here
+CAPACITIES_STRUCTURE_ID=your_capacities_structure_id_here
+CAPACITIES_TEXT_PROPERTY_ID=your_capacities_text_property_id_here
+
 # Optional Configuration
 # Number of days to look back for initial sync (default: 7)
 SYNC_DAYS_BACK=7

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ TWOS_USER_ID=your_twos_user_id_here
 TWOS_TOKEN=your_twos_api_token_here
 CAPACITIES_TOKEN=your_capacities_token_here
 CAPACITIES_SPACE_ID=your_capacities_space_id_here
+CAPACITIES_STRUCTURE_ID=your_capacities_structure_id_here
+CAPACITIES_TEXT_PROPERTY_ID=your_capacities_text_property_id_here
 
 # Optional settings
 SYNC_DAYS_BACK=7
@@ -212,6 +214,10 @@ flake8 readwise_twos_sync/
 | `READWISE_TOKEN` | Your Readwise API token | Required |
 | `TWOS_USER_ID` | Your Twos user ID | Required |
 | `TWOS_TOKEN` | Your Twos API token | Required |
+| `CAPACITIES_TOKEN` | Capacities API token | Optional |
+| `CAPACITIES_SPACE_ID` | Capacities space ID | Optional |
+| `CAPACITIES_STRUCTURE_ID` | Capacities structure ID | Optional |
+| `CAPACITIES_TEXT_PROPERTY_ID` | Capacities text property ID | Optional |
 | `SYNC_DAYS_BACK` | Days to look back for initial sync | 7 |
 | `LAST_SYNC_FILE` | Path to sync timestamp file | `last_sync.json` |
 

--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -12,6 +12,10 @@ def ensure_capacities_columns(engine):
         statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_space_id VARCHAR(255)"))
     if 'capacities_token' not in columns:
         statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_token TEXT"))
+    if 'capacities_structure_id' not in columns:
+        statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_structure_id VARCHAR(255)"))
+    if 'capacities_text_property_id' not in columns:
+        statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_text_property_id VARCHAR(255)"))
     if statements:
         with engine.begin() as conn:
             for stmt in statements:

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -198,7 +198,7 @@ def post_highlights_to_twos(highlights, books, twos_user_id, twos_token):
     return successful_posts
 
 
-def post_highlights_to_capacities(highlights, books, space_id, token):
+def post_highlights_to_capacities(highlights, books, space_id, token, structure_id, text_property_id):
     """Post highlights to Capacities."""
     api_url = f"https://api.capacities.io/spaces/{space_id}/blocks"
     headers = {
@@ -207,8 +207,16 @@ def post_highlights_to_capacities(highlights, books, space_id, token):
     }
     today_title = datetime.now().strftime("%Y-%m-%d")
 
+    def build_payload(text: str) -> dict:
+        return {
+            "structureId": structure_id,
+            "properties": {
+                text_property_id: {"type": "text", "value": text}
+            },
+        }
+
     if not highlights:
-        payload = {"content": f"No new highlights for {today_title}"}
+        payload = build_payload(f"No new highlights for {today_title}")
         try:
             response = requests.post(api_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
@@ -226,13 +234,13 @@ def post_highlights_to_capacities(highlights, books, space_id, token):
             title = book_meta["title"]
             author = book_meta["author"]
             note_text = f"{title}, {author}: {text}"
-            payload = {"content": note_text.strip()}
+            payload = build_payload(note_text.strip())
             response = requests.post(api_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
         except requests.RequestException as e:
             logger.error(f"Failed to post highlight to Capacities: {e}")
 
-def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None, capacities_space_id=None, days_back=1, user_id=None):
+def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None, capacities_space_id=None, capacities_structure_id=None, capacities_text_property_id=None, days_back=1, user_id=None):
     """Perform a sync from Readwise to Twos and Capacities."""
     logger.info(f"Starting sync for user {user_id}, looking back {days_back} days")
     
@@ -247,13 +255,27 @@ def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None
         if highlights:
             books = fetch_all_books(readwise_token)
             post_highlights_to_twos(highlights, books, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities(highlights, books, capacities_space_id, capacities_token)
+            if all([capacities_token, capacities_space_id, capacities_structure_id, capacities_text_property_id]):
+                post_highlights_to_capacities(
+                    highlights,
+                    books,
+                    capacities_space_id,
+                    capacities_token,
+                    capacities_structure_id,
+                    capacities_text_property_id,
+                )
             message = f"Successfully synced {len(highlights)} highlights to destinations!"
         else:
             post_highlights_to_twos([], {}, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities([], {}, capacities_space_id, capacities_token)
+            if all([capacities_token, capacities_space_id, capacities_structure_id, capacities_text_property_id]):
+                post_highlights_to_capacities(
+                    [],
+                    {},
+                    capacities_space_id,
+                    capacities_token,
+                    capacities_structure_id,
+                    capacities_text_property_id,
+                )
             message = "No new highlights found, but posted update to destinations."
         
         # Log successful sync
@@ -318,6 +340,8 @@ def run_scheduled_sync(user_id):
             cipher_suite.decrypt(creds_result.capacities_token.encode()).decode()
             if creds_result.capacities_token else None
         )
+        capacities_structure_id = creds_result.capacities_structure_id
+        capacities_text_property_id = creds_result.capacities_text_property_id
 
         # Perform sync (only 1 day back for scheduled syncs)
         result = perform_sync(
@@ -326,6 +350,8 @@ def run_scheduled_sync(user_id):
             twos_token=twos_token,
             capacities_token=capacities_token,
             capacities_space_id=creds_result.capacities_space_id,
+            capacities_structure_id=capacities_structure_id,
+            capacities_text_property_id=capacities_text_property_id,
             days_back=1,  # Only sync yesterday's highlights
             user_id=user_id
         )

--- a/backend/sync_service.py
+++ b/backend/sync_service.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None, capacities_space_id=None, days_back=7, user_id=None):
+def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None, capacities_space_id=None, capacities_structure_id=None, capacities_text_property_id=None, days_back=7, user_id=None):
     """
     Perform a sync from Readwise to Twos and Capacities.
     
@@ -39,13 +39,27 @@ def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None
         if highlights:
             books = fetch_all_books(readwise_token)
             post_highlights_to_twos(highlights, books, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities(highlights, books, capacities_space_id, capacities_token)
+            if all([capacities_token, capacities_space_id, capacities_structure_id, capacities_text_property_id]):
+                post_highlights_to_capacities(
+                    highlights,
+                    books,
+                    capacities_space_id,
+                    capacities_token,
+                    capacities_structure_id,
+                    capacities_text_property_id,
+                )
             message = f"Successfully synced {len(highlights)} highlights to destinations!"
         else:
             post_highlights_to_twos([], {}, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities([], {}, capacities_space_id, capacities_token)
+            if all([capacities_token, capacities_space_id, capacities_structure_id, capacities_text_property_id]):
+                post_highlights_to_capacities(
+                    [],
+                    {},
+                    capacities_space_id,
+                    capacities_token,
+                    capacities_structure_id,
+                    capacities_text_property_id,
+                )
             message = "No new highlights found, but posted update to destinations."
         
         # Return success info for logging by caller
@@ -182,7 +196,7 @@ def post_highlights_to_twos(highlights, books, twos_user_id, twos_token):
         logger.warning(f"Failed to post {failed_posts} highlights")
 
 
-def post_highlights_to_capacities(highlights, books, space_id, token):
+def post_highlights_to_capacities(highlights, books, space_id, token, structure_id, text_property_id):
     """Post highlights to Capacities."""
     api_url = f"https://api.capacities.io/spaces/{space_id}/blocks"
     headers = {
@@ -191,8 +205,16 @@ def post_highlights_to_capacities(highlights, books, space_id, token):
     }
     today_title = datetime.now().strftime("%Y-%m-%d")
 
+    def build_payload(text: str) -> dict:
+        return {
+            "structureId": structure_id,
+            "properties": {
+                text_property_id: {"type": "text", "value": text}
+            },
+        }
+
     if not highlights:
-        payload = {"content": f"No new highlights for {today_title}"}
+        payload = build_payload(f"No new highlights for {today_title}")
         try:
             response = requests.post(api_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
@@ -211,7 +233,7 @@ def post_highlights_to_capacities(highlights, books, space_id, token):
             title = book_meta["title"]
             author = book_meta["author"]
             note_text = f"{title}, {author}: {text}"
-            payload = {"content": note_text.strip()}
+            payload = build_payload(note_text.strip())
             response = requests.post(api_url, headers=headers, json=payload, timeout=30)
             response.raise_for_status()
         except requests.RequestException as e:

--- a/readwise_twos_sync/cli.py
+++ b/readwise_twos_sync/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -31,6 +32,8 @@ Environment Variables:
   TWOS_TOKEN        Your Twos API token (required)
   CAPACITIES_TOKEN  Capacities API token (optional)
   CAPACITIES_SPACE_ID Capacities space ID (optional)
+  CAPACITIES_STRUCTURE_ID Capacities structure ID (optional)
+  CAPACITIES_TEXT_PROPERTY_ID Capacities text property ID (optional)
   SYNC_DAYS_BACK    Days to look back for initial sync (default: 7)
   LAST_SYNC_FILE    Path to sync timestamp file (default: last_sync.json)
 
@@ -52,6 +55,18 @@ Examples:
         action="store_true",
         help="Enable verbose logging"
     )
+
+    parser.add_argument(
+        "--capacities-structure-id",
+        type=str,
+        help="Capacities structure ID (optional)"
+    )
+
+    parser.add_argument(
+        "--capacities-text-property-id",
+        type=str,
+        help="Capacities text property ID (optional)"
+    )
     
     parser.add_argument(
         "--version",
@@ -60,11 +75,17 @@ Examples:
     )
     
     args = parser.parse_args()
-    
+
     # Setup logging
     setup_logging(args.verbose)
     logger = logging.getLogger(__name__)
-    
+
+    # Allow CLI args to override environment variables
+    if args.capacities_structure_id:
+        os.environ["CAPACITIES_STRUCTURE_ID"] = args.capacities_structure_id
+    if args.capacities_text_property_id:
+        os.environ["CAPACITIES_TEXT_PROPERTY_ID"] = args.capacities_text_property_id
+
     try:
         # Initialize configuration
         config = Config(env_file=args.env_file)

--- a/readwise_twos_sync/config.py
+++ b/readwise_twos_sync/config.py
@@ -48,6 +48,16 @@ class Config:
         return os.environ.get("CAPACITIES_SPACE_ID")
 
     @property
+    def capacities_structure_id(self) -> Optional[str]:
+        """Get Capacities structure ID if provided."""
+        return os.environ.get("CAPACITIES_STRUCTURE_ID")
+
+    @property
+    def capacities_text_property_id(self) -> Optional[str]:
+        """Get Capacities text property ID if provided."""
+        return os.environ.get("CAPACITIES_TEXT_PROPERTY_ID")
+
+    @property
     def sync_days_back(self) -> int:
         """Number of days to look back for initial sync."""
         return int(os.environ.get("SYNC_DAYS_BACK", "7"))
@@ -68,17 +78,24 @@ class Config:
                 "Please set these in your environment or .env file.",
             )
 
-        # Capacities credentials are optional, but if one is provided,
-        # ensure both CAPACITIES_TOKEN and CAPACITIES_SPACE_ID are set.
+        # Capacities credentials are optional, but if any is provided,
+        # ensure CAPACITIES_TOKEN, CAPACITIES_SPACE_ID, CAPACITIES_STRUCTURE_ID,
+        # and CAPACITIES_TEXT_PROPERTY_ID are all set.
         cap_token = os.environ.get("CAPACITIES_TOKEN")
         cap_space = os.environ.get("CAPACITIES_SPACE_ID")
-        if cap_token or cap_space:
-            if not (cap_token and cap_space):
-                missing = []
-                if not cap_token:
-                    missing.append("CAPACITIES_TOKEN")
-                if not cap_space:
-                    missing.append("CAPACITIES_SPACE_ID")
+        cap_structure = os.environ.get("CAPACITIES_STRUCTURE_ID")
+        cap_text_prop = os.environ.get("CAPACITIES_TEXT_PROPERTY_ID")
+        if any([cap_token, cap_space, cap_structure, cap_text_prop]):
+            missing = []
+            if not cap_token:
+                missing.append("CAPACITIES_TOKEN")
+            if not cap_space:
+                missing.append("CAPACITIES_SPACE_ID")
+            if not cap_structure:
+                missing.append("CAPACITIES_STRUCTURE_ID")
+            if not cap_text_prop:
+                missing.append("CAPACITIES_TEXT_PROPERTY_ID")
+            if missing:
                 raise ValueError(
                     f"Missing required Capacities environment variables: {', '.join(missing)}"
                 )

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -360,15 +360,25 @@
                             <div class="api-key" id="twos-token">••••••••••••</div>
                         </div>
 
-                        <div class="mb-3">
-                            <label class="form-label">Capacities Space ID</label>
-                            <div class="api-key" id="capacities-space-id">Not set</div>
-                        </div>
+        <div class="mb-3">
+            <label class="form-label">Capacities Space ID</label>
+            <div class="api-key" id="capacities-space-id">Not set</div>
+        </div>
 
-                        <div class="mb-3">
-                            <label class="form-label">Capacities API Token</label>
-                            <div class="api-key" id="capacities-token">Not set</div>
-                        </div>
+        <div class="mb-3">
+            <label class="form-label">Capacities API Token</label>
+            <div class="api-key" id="capacities-token">Not set</div>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Capacities Structure ID</label>
+            <div class="api-key" id="capacities-structure-id">Not set</div>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Capacities Text Property ID</label>
+            <div class="api-key" id="capacities-text-property-id">Not set</div>
+        </div>
                         
                         <div class="d-grid">
                             <button class="btn btn-primary" id="update-credentials-btn">
@@ -439,21 +449,31 @@
                             </div>
                         </div>
 
-                        <div class="mb-3">
-                            <label for="capacities_space_id" class="form-label">Capacities Space ID</label>
-                            <input type="text" class="form-control" id="capacities_space_id">
-                            <div class="form-text">
-                                From your Capacities workspace settings
-                            </div>
-                        </div>
+        <div class="mb-3">
+            <label for="capacities_space_id" class="form-label">Capacities Space ID</label>
+            <input type="text" class="form-control" id="capacities_space_id">
+            <div class="form-text">
+                From your Capacities workspace settings
+            </div>
+        </div>
 
-                        <div class="mb-3">
-                            <label for="capacities_token" class="form-label">Capacities API Token</label>
-                            <input type="text" class="form-control" id="capacities_token">
-                            <div class="form-text">
-                                Generate a token in Capacities account settings
-                            </div>
-                        </div>
+        <div class="mb-3">
+            <label for="capacities_token" class="form-label">Capacities API Token</label>
+            <input type="text" class="form-control" id="capacities_token">
+            <div class="form-text">
+                Generate a token in Capacities account settings
+            </div>
+        </div>
+
+        <div class="mb-3">
+            <label for="capacities_structure_id" class="form-label">Capacities Structure ID</label>
+            <input type="text" class="form-control" id="capacities_structure_id">
+        </div>
+
+        <div class="mb-3">
+            <label for="capacities_text_property_id" class="form-label">Capacities Text Property ID</label>
+            <input type="text" class="form-control" id="capacities_text_property_id">
+        </div>
                     </form>
                 </div>
                 <div class="modal-footer">
@@ -658,6 +678,8 @@
             document.getElementById('twos-token').textContent = credentials.twos_token;
             document.getElementById('capacities-space-id').textContent = credentials.capacities_space_id || 'Not set';
             document.getElementById('capacities-token').textContent = credentials.capacities_token || 'Not set';
+            document.getElementById('capacities-structure-id').textContent = credentials.capacities_structure_id || 'Not set';
+            document.getElementById('capacities-text-property-id').textContent = credentials.capacities_text_property_id || 'Not set';
         }
         
         // Update history display
@@ -870,6 +892,8 @@
             const twosToken = document.getElementById('twos_token').value;
             const capacitiesSpaceId = document.getElementById('capacities_space_id').value;
             const capacitiesToken = document.getElementById('capacities_token').value;
+            const capacitiesStructureId = document.getElementById('capacities_structure_id').value;
+            const capacitiesTextPropertyId = document.getElementById('capacities_text_property_id').value;
 
             if (!readwiseToken || !twosUserId || !twosToken) {
                 alert('Readwise and Twos fields are required');
@@ -892,7 +916,9 @@
                         twos_user_id: twosUserId,
                         twos_token: twosToken,
                         capacities_space_id: capacitiesSpaceId || null,
-                        capacities_token: capacitiesToken || null
+                        capacities_token: capacitiesToken || null,
+                        capacities_structure_id: capacitiesStructureId || null,
+                        capacities_text_property_id: capacitiesTextPropertyId || null
                     })
                 });
                 

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -70,6 +70,8 @@ class TestAPIIntegration:
             twos_token='test_twos_token',
             capacities_token='cap_token',
             capacities_space_id='space123',
+            capacities_structure_id='struct123',
+            capacities_text_property_id='textprop123',
             days_back=1
         )
         
@@ -96,6 +98,8 @@ class TestAPIIntegration:
                 twos_token='test_twos_token',
                 capacities_token='cap_token',
                 capacities_space_id='space123',
+                capacities_structure_id='struct123',
+                capacities_text_property_id='textprop123',
                 days_back=1
             )
         
@@ -168,6 +172,8 @@ class TestAPIIntegration:
             twos_token='test_twos_token',
             capacities_token='cap_token',
             capacities_space_id='space123',
+            capacities_structure_id='struct123',
+            capacities_text_property_id='textprop123',
             days_back=1
         )
         
@@ -188,6 +194,8 @@ class TestAPIIntegration:
                 twos_token='test_token',
                 capacities_token='cap_token',
                 capacities_space_id='space123',
+                capacities_structure_id='struct123',
+                capacities_text_property_id='textprop123',
                 days_back=1
             )
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -42,5 +42,7 @@ def test_app_auto_adds_capacities_columns(tmp_path):
             columns = [c["name"] for c in inspector.get_columns("api_credentials")]
             assert "capacities_space_id" in columns
             assert "capacities_token" in columns
+            assert "capacities_structure_id" in columns
+            assert "capacities_text_property_id" in columns
     finally:
         app_module.scheduler.shutdown(wait=False)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -155,7 +155,9 @@ class TestScheduler:
                 twos_user_id='test_twos_user',
                 twos_token=encrypted_twos.decode(),
                 capacities_space_id='space123',
-                capacities_token=encrypted_cap.decode()
+                capacities_token=encrypted_cap.decode(),
+                capacities_structure_id='struct123',
+                capacities_text_property_id='textprop123'
             )
             db.session.add(creds)
             db.session.commit()
@@ -182,6 +184,8 @@ class TestScheduler:
         assert call_args['twos_user_id'] == 'test_twos_user'
         assert call_args['capacities_space_id'] == 'space123'
         assert call_args['capacities_token'] == 'cap_token'
+        assert call_args['capacities_structure_id'] == 'struct123'
+        assert call_args['capacities_text_property_id'] == 'textprop123'
         assert call_args['days_back'] == 1
         assert call_args['user_id'] == user_id
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -23,7 +23,9 @@ class TestSyncFunctionality:
                     'twos_user_id': 'test_twos_user',
                     'twos_token': 'test_twos_token',
                     'capacities_space_id': 'space123',
-                    'capacities_token': 'cap_token'
+                    'capacities_token': 'cap_token',
+                    'capacities_structure_id': 'struct123',
+                    'capacities_text_property_id': 'textprop123'
                 }
             )
             assert response.status_code == 200
@@ -35,6 +37,8 @@ class TestSyncFunctionality:
             assert creds is not None
             assert creds.twos_user_id == 'test_twos_user'
             assert creds.capacities_space_id == 'space123'
+            assert creds.capacities_structure_id == 'struct123'
+            assert creds.capacities_text_property_id == 'textprop123'
     
     def test_get_credentials(self, app, client, auth_headers):
         """Test retrieving API credentials."""
@@ -52,7 +56,9 @@ class TestSyncFunctionality:
                 twos_user_id='test_twos_user',
                 twos_token=encrypted_twos.decode(),
                 capacities_space_id='space123',
-                capacities_token=encrypted_cap.decode()
+                capacities_token=encrypted_cap.decode(),
+                capacities_structure_id='struct123',
+                capacities_text_property_id='textprop123'
             )
             db.session.add(creds)
             db.session.commit()
@@ -64,6 +70,8 @@ class TestSyncFunctionality:
             assert data['readwise_token'] == 'test_readwise_token'
             assert data['twos_user_id'] == 'test_twos_user'
             assert data['capacities_space_id'] == 'space123'
+            assert data['capacities_structure_id'] == 'struct123'
+            assert data['capacities_text_property_id'] == 'textprop123'
     
     def test_manual_sync(self, app, client, auth_headers, mock_readwise_api, mock_post_requests):
         """Test manual sync operation."""
@@ -81,7 +89,9 @@ class TestSyncFunctionality:
                 twos_user_id='test_twos_user',
                 twos_token=encrypted_twos.decode(),
                 capacities_space_id='space123',
-                capacities_token=encrypted_cap.decode()
+                capacities_token=encrypted_cap.decode(),
+                capacities_structure_id='struct123',
+                capacities_text_property_id='textprop123'
             )
             db.session.add(creds)
             db.session.commit()


### PR DESCRIPTION
## Summary
- support CAPACITIES_STRUCTURE_ID and CAPACITIES_TEXT_PROPERTY_ID env vars with validation
- allow CLI to accept and set Capacities structure and property IDs
- persist new Capacities fields in backend API and dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68967efa45048332b71762cbc0d4af45