### PR TITLE
Use CapacitiesClient for Capacities integrations

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,6 +19,7 @@ import requests
 from dotenv import load_dotenv
 import pytz
 from db_utils import ensure_capacities_columns
+from readwise_twos_sync.capacities_client import CapacitiesClient
 
 # Load environment variables
 load_dotenv()
@@ -510,17 +511,23 @@ def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None
         
         # Fetch highlights
         highlights = fetch_highlights_since(readwise_token, since)
-        
+
+        capacities_client = None
+        if capacities_token and capacities_space_id:
+            capacities_client = CapacitiesClient(
+                token=capacities_token, space_id=capacities_space_id
+            )
+
         if highlights:
             books = fetch_all_books(readwise_token)
             post_highlights_to_twos(highlights, books, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities(highlights, books, capacities_space_id, capacities_token)
+            if capacities_client:
+                capacities_client.post_highlights(highlights, books)
             message = f"Successfully synced {len(highlights)} highlights to destinations!"
         else:
             post_highlights_to_twos([], {}, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities([], {}, capacities_space_id, capacities_token)
+            if capacities_client:
+                capacities_client.post_highlights([], {})
             message = "No new highlights found, but posted update to destinations."
         
         # Log successful sync
@@ -676,41 +683,6 @@ def post_highlights_to_twos(highlights, books, twos_user_id, twos_token):
     
     return successful_posts
 
-
-def post_highlights_to_capacities(highlights, books, space_id, token):
-    """Post highlights to Capacities."""
-    api_url = f"https://api.capacities.io/spaces/{space_id}/blocks"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    today_title = datetime.now().strftime("%Y-%m-%d")
-
-    if not highlights:
-        payload = {"content": f"No new highlights for {today_title}"}
-        try:
-            response = requests.post(api_url, headers=headers, json=payload, timeout=30)
-            response.raise_for_status()
-            logger.info("Posted 'no highlights' message to Capacities")
-        except requests.RequestException as e:
-            logger.error(f"Failed to post no-highlights message to Capacities: {e}")
-        return
-
-    for highlight in highlights:
-        try:
-            book_id = highlight.get("book_id")
-            text = highlight.get("text")
-            book_meta = books.get(book_id)
-            if not book_meta:
-                continue
-            title = book_meta["title"]
-            author = book_meta["author"]
-            note_text = f"{title}, {author}: {text}"
-            payload = {"content": note_text.strip()}
-            response = requests.post(api_url, headers=headers, json=payload, timeout=30)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(f"Failed to post highlight to Capacities: {e}")
 
 
 # ---- Sync Routes ----

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 from cryptography.fernet import Fernet
 import pytz
 from db_utils import ensure_capacities_columns
+from readwise_twos_sync.capacities_client import CapacitiesClient
 
 # Load environment variables
 load_dotenv()
@@ -198,40 +199,6 @@ def post_highlights_to_twos(highlights, books, twos_user_id, twos_token):
     return successful_posts
 
 
-def post_highlights_to_capacities(highlights, books, space_id, token):
-    """Post highlights to Capacities."""
-    api_url = f"https://api.capacities.io/spaces/{space_id}/blocks"
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "Content-Type": "application/json",
-    }
-    today_title = datetime.now().strftime("%Y-%m-%d")
-
-    if not highlights:
-        payload = {"content": f"No new highlights for {today_title}"}
-        try:
-            response = requests.post(api_url, headers=headers, json=payload, timeout=30)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(f"Failed to post no-highlights message to Capacities: {e}")
-        return
-
-    for highlight in highlights:
-        try:
-            book_id = highlight.get("book_id")
-            text = highlight.get("text")
-            book_meta = books.get(book_id)
-            if not book_meta:
-                continue
-            title = book_meta["title"]
-            author = book_meta["author"]
-            note_text = f"{title}, {author}: {text}"
-            payload = {"content": note_text.strip()}
-            response = requests.post(api_url, headers=headers, json=payload, timeout=30)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            logger.error(f"Failed to post highlight to Capacities: {e}")
-
 def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None, capacities_space_id=None, days_back=1, user_id=None):
     """Perform a sync from Readwise to Twos and Capacities."""
     logger.info(f"Starting sync for user {user_id}, looking back {days_back} days")
@@ -243,17 +210,23 @@ def perform_sync(readwise_token, twos_user_id, twos_token, capacities_token=None
         
         # Fetch highlights
         highlights = fetch_highlights_since(readwise_token, since)
-        
+
+        capacities_client = None
+        if capacities_token and capacities_space_id:
+            capacities_client = CapacitiesClient(
+                token=capacities_token, space_id=capacities_space_id
+            )
+
         if highlights:
             books = fetch_all_books(readwise_token)
             post_highlights_to_twos(highlights, books, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities(highlights, books, capacities_space_id, capacities_token)
+            if capacities_client:
+                capacities_client.post_highlights(highlights, books)
             message = f"Successfully synced {len(highlights)} highlights to destinations!"
         else:
             post_highlights_to_twos([], {}, twos_user_id, twos_token)
-            if capacities_token and capacities_space_id:
-                post_highlights_to_capacities([], {}, capacities_space_id, capacities_token)
+            if capacities_client:
+                capacities_client.post_highlights([], {})
             message = "No new highlights found, but posted update to destinations."
         
         # Log successful sync

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,8 +125,8 @@ def mock_readwise_api():
 
 @pytest.fixture
 def mock_post_requests():
-    """Mock external POST requests (Twos and Capacities)."""
-    with patch('backend.app.requests.post') as mock_post:
+    """Mock external POST requests to third-party services."""
+    with patch('requests.post') as mock_post:
         mock_response = Mock()
         mock_response.raise_for_status.return_value = None
         mock_response.status_code = 200

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -80,7 +80,12 @@ class TestAPIIntegration:
         
         # Verify API calls were made
         assert mock_get.call_count >= 2  # At least highlights and books calls
-        assert mock_post.call_count == 4  # Two highlights to Twos and two to Capacities
+        assert mock_post.call_count == 3  # Two highlights to Twos and one to Capacities
+
+        twos_calls = [c for c in mock_post.call_args_list if 'twosapp' in c.args[0]]
+        cap_calls = [c for c in mock_post.call_args_list if 'capacities' in c.args[0]]
+        assert len(twos_calls) == 2
+        assert len(cap_calls) == 1
     
     @patch('requests.get')
     def test_readwise_api_error(self, mock_get):
@@ -176,8 +181,12 @@ class TestAPIIntegration:
         assert result['highlights_synced'] == 0
         assert 'No new highlights' in result['message']
         
-        # Should still post to Twos (no highlights message)
+        # Should still post to both services (one each)
         assert mock_post.call_count == 2
+        twos_calls = [c for c in mock_post.call_args_list if 'twosapp' in c.args[0]]
+        cap_calls = [c for c in mock_post.call_args_list if 'capacities' in c.args[0]]
+        assert len(twos_calls) == 1
+        assert len(cap_calls) == 1
     
     def test_invalid_sync_parameters(self):
         """Test sync with invalid parameters."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,7 +68,7 @@ class TestSyncFunctionality:
     def test_manual_sync(self, app, client, auth_headers, mock_readwise_api, mock_post_requests):
         """Test manual sync operation."""
         headers, user_id = auth_headers
-        
+
         with app.app_context():
             # Store credentials
             encrypted_readwise = cipher_suite.encrypt('test_readwise_token'.encode())
@@ -85,27 +85,32 @@ class TestSyncFunctionality:
             )
             db.session.add(creds)
             db.session.commit()
-            
-            # Perform sync
-            response = client.post('/api/sync',
-                headers=headers,
-                json={'days_back': 1}
-            )
-            assert response.status_code == 200
-            data = json.loads(response.data)
-            assert data['success'] is True
-            assert 'highlights_synced' in data
-            
-            # Verify sync log was created
-            sync_log = SyncLog.query.filter_by(user_id=user_id).first()
-            assert sync_log is not None
-            assert sync_log.status == 'success'
 
-            # Ensure posts were made to both services (2 highlights each)
-            twos_calls = [c for c in mock_post_requests.call_args_list if 'twosapp' in c.args[0]]
-            cap_calls = [c for c in mock_post_requests.call_args_list if 'capacities' in c.args[0]]
-            assert len(twos_calls) == 2
-            assert len(cap_calls) == 2
+            with patch('backend.app.CapacitiesClient') as MockCapClient:
+                mock_client = Mock()
+                MockCapClient.return_value = mock_client
+
+                # Perform sync
+                response = client.post(
+                    '/api/sync', headers=headers, json={'days_back': 1}
+                )
+                assert response.status_code == 200
+                data = json.loads(response.data)
+                assert data['success'] is True
+                assert 'highlights_synced' in data
+
+                # Verify sync log was created
+                sync_log = SyncLog.query.filter_by(user_id=user_id).first()
+                assert sync_log is not None
+                assert sync_log.status == 'success'
+
+                # Ensure posts were made to Twos (2 highlights)
+                twos_calls = [c for c in mock_post_requests.call_args_list if 'twosapp' in c.args[0]]
+                assert len(twos_calls) == 2
+
+                # Verify Capacities client usage
+                MockCapClient.assert_called_once_with(token='cap_token', space_id='space123')
+                mock_client.post_highlights.assert_called_once()
     
     def test_sync_without_credentials(self, client, auth_headers):
         """Test sync without stored credentials."""


### PR DESCRIPTION
## Summary
- replace direct Capacities API calls with `CapacitiesClient.post_highlights`
- remove legacy Capacities helper functions and wire client into sync flows
- update tests to mock Capacities client and new request counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68975e90c4408332a0adc9d6c94f941c