### PR TITLE
feat: allow selective sync and secure credentials

### DIFF
--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -6,12 +6,20 @@ def ensure_capacities_columns(engine):
     inspector = inspect(engine)
     if not inspector.has_table('api_credentials'):
         return
-    columns = [col['name'] for col in inspector.get_columns('api_credentials')]
+    columns_info = inspector.get_columns('api_credentials')
+    columns = {col['name']: col for col in columns_info}
     statements = []
     if 'capacities_space_id' not in columns:
         statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_space_id VARCHAR(255)"))
     if 'capacities_token' not in columns:
         statements.append(text("ALTER TABLE api_credentials ADD COLUMN capacities_token TEXT"))
+    # Ensure Twos columns are nullable
+    twos_user_col = columns.get('twos_user_id')
+    if twos_user_col and not twos_user_col.get('nullable', True):
+        statements.append(text("ALTER TABLE api_credentials ALTER COLUMN twos_user_id DROP NOT NULL"))
+    twos_token_col = columns.get('twos_token')
+    if twos_token_col and not twos_token_col.get('nullable', True):
+        statements.append(text("ALTER TABLE api_credentials ALTER COLUMN twos_token DROP NOT NULL"))
     if statements:
         with engine.begin() as conn:
             for stmt in statements:

--- a/migrate_database.py
+++ b/migrate_database.py
@@ -104,7 +104,8 @@ def migrate_database():
             print("\n📋 Creating api_credentials table...")
             db.create_all()
         else:
-            cred_columns = [col['name'] for col in inspector.get_columns('api_credentials')]
+            cred_columns_info = inspector.get_columns('api_credentials')
+            cred_columns = [col['name'] for col in cred_columns_info]
             print(f"\n📋 api_credentials columns: {cred_columns}")
             cred_migrations = []
 
@@ -113,6 +114,11 @@ def migrate_database():
 
             if 'capacities_token' not in cred_columns:
                 cred_migrations.append("ADD COLUMN capacities_token TEXT")
+
+            # Ensure Twos columns are nullable
+            for col in cred_columns_info:
+                if col['name'] in ('twos_user_id', 'twos_token') and not col.get('nullable', True):
+                    cred_migrations.append(f"ALTER COLUMN {col['name']} DROP NOT NULL")
 
             if cred_migrations:
                 print(f"🔧 Applying {len(cred_migrations)} api_credentials migrations...")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -423,35 +423,49 @@
                             </div>
                         </div>
                         
-                        <div class="mb-3">
-                            <label for="twos_user_id" class="form-label">Twos User ID</label>
-                            <input type="text" class="form-control" id="twos_user_id" required>
-                            <div class="form-text">
-                                Find this in your Twos app: Settings → API
-                            </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="enable_twos" checked>
+                            <label class="form-check-label" for="enable_twos">Sync to Twos</label>
                         </div>
-                        
-                        <div class="mb-3">
-                            <label for="twos_token" class="form-label">Twos API Token</label>
-                            <input type="text" class="form-control" id="twos_token" required>
-                            <div class="form-text">
-                                Find this in your Twos app: Settings → API
+
+                        <div id="twos-section">
+                            <div class="mb-3">
+                                <label for="twos_user_id" class="form-label">Twos User ID</label>
+                                <input type="text" class="form-control" id="twos_user_id">
+                                <div class="form-text">
+                                    Find this in your Twos app: Settings → API
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="twos_token" class="form-label">Twos API Token</label>
+                                <input type="text" class="form-control" id="twos_token">
+                                <div class="form-text">
+                                    Find this in your Twos app: Settings → API
+                                </div>
                             </div>
                         </div>
 
-                        <div class="mb-3">
-                            <label for="capacities_space_id" class="form-label">Capacities Space ID</label>
-                            <input type="text" class="form-control" id="capacities_space_id">
-                            <div class="form-text">
-                                From your Capacities workspace settings
-                            </div>
+                        <div class="form-check form-switch mb-3">
+                            <input class="form-check-input" type="checkbox" id="enable_capacities">
+                            <label class="form-check-label" for="enable_capacities">Sync to Capacities</label>
                         </div>
 
-                        <div class="mb-3">
-                            <label for="capacities_token" class="form-label">Capacities API Token</label>
-                            <input type="text" class="form-control" id="capacities_token">
-                            <div class="form-text">
-                                Generate a token in Capacities account settings
+                        <div id="capacities-section" style="display: none;">
+                            <div class="mb-3">
+                                <label for="capacities_space_id" class="form-label">Capacities Space ID</label>
+                                <input type="text" class="form-control" id="capacities_space_id">
+                                <div class="form-text">
+                                    From your Capacities workspace settings
+                                </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="capacities_token" class="form-label">Capacities API Token</label>
+                                <input type="text" class="form-control" id="capacities_token">
+                                <div class="form-text">
+                                    Generate a token in Capacities account settings
+                                </div>
                             </div>
                         </div>
                     </form>
@@ -520,6 +534,12 @@
     <script>
         // API URL
         const API_URL = 'https://web-production-0b0f42.up.railway.app';
+        let currentCredentials = null;
+
+        function maskToken(token) {
+            if (!token) return 'Not set';
+            return token.length > 8 ? `${token.slice(0,4)}...${token.slice(-4)}` : '****';
+        }
         
         // Check if user is logged in
         function checkAuth() {
@@ -584,8 +604,9 @@
                 }
                 
                 const credentials = await response.json();
+                currentCredentials = credentials;
                 updateCredentialsDisplay(credentials);
-                
+
                 return credentials;
             } catch (error) {
                 console.error('Error fetching credentials:', error);
@@ -653,11 +674,31 @@
         
         // Update credentials display
         function updateCredentialsDisplay(credentials) {
-            document.getElementById('readwise-token').textContent = credentials.readwise_token;
-            document.getElementById('twos-user-id').textContent = credentials.twos_user_id;
-            document.getElementById('twos-token').textContent = credentials.twos_token;
+            document.getElementById('readwise-token').textContent = maskToken(credentials.readwise_token);
+            document.getElementById('twos-user-id').textContent = credentials.twos_user_id || 'Not set';
+            document.getElementById('twos-token').textContent = maskToken(credentials.twos_token);
             document.getElementById('capacities-space-id').textContent = credentials.capacities_space_id || 'Not set';
-            document.getElementById('capacities-token').textContent = credentials.capacities_token || 'Not set';
+            document.getElementById('capacities-token').textContent = maskToken(credentials.capacities_token);
+        }
+
+        function toggleTwosFields() {
+            const enabled = document.getElementById('enable_twos').checked;
+            document.getElementById('twos-section').style.display = enabled ? '' : 'none';
+            ['twos_user_id', 'twos_token'].forEach(id => {
+                const el = document.getElementById(id);
+                el.disabled = !enabled;
+                el.required = enabled;
+            });
+        }
+
+        function toggleCapacitiesFields() {
+            const enabled = document.getElementById('enable_capacities').checked;
+            document.getElementById('capacities-section').style.display = enabled ? '' : 'none';
+            ['capacities_space_id', 'capacities_token'].forEach(id => {
+                const el = document.getElementById(id);
+                el.disabled = !enabled;
+                el.required = enabled;
+            });
         }
         
         // Update history display
@@ -866,13 +907,27 @@
             if (!token) return;
 
             const readwiseToken = document.getElementById('readwise_token').value;
+            const enableTwos = document.getElementById('enable_twos').checked;
+            const enableCapacities = document.getElementById('enable_capacities').checked;
             const twosUserId = document.getElementById('twos_user_id').value;
             const twosToken = document.getElementById('twos_token').value;
             const capacitiesSpaceId = document.getElementById('capacities_space_id').value;
             const capacitiesToken = document.getElementById('capacities_token').value;
 
-            if (!readwiseToken || !twosUserId || !twosToken) {
-                alert('Readwise and Twos fields are required');
+            if (!readwiseToken) {
+                alert('Readwise token is required');
+                return;
+            }
+            if (!enableTwos && !enableCapacities) {
+                alert('Select at least one destination');
+                return;
+            }
+            if (enableTwos && (!twosUserId || !twosToken)) {
+                alert('Twos fields are required');
+                return;
+            }
+            if (enableCapacities && (!capacitiesSpaceId || !capacitiesToken)) {
+                alert('Capacities fields are required');
                 return;
             }
             
@@ -889,10 +944,10 @@
                     },
                     body: JSON.stringify({
                         readwise_token: readwiseToken,
-                        twos_user_id: twosUserId,
-                        twos_token: twosToken,
-                        capacities_space_id: capacitiesSpaceId || null,
-                        capacities_token: capacitiesToken || null
+                        twos_user_id: enableTwos ? twosUserId : null,
+                        twos_token: enableTwos ? twosToken : null,
+                        capacities_space_id: enableCapacities ? capacitiesSpaceId : null,
+                        capacities_token: enableCapacities ? capacitiesToken : null
                     })
                 });
                 
@@ -958,11 +1013,26 @@
             document.getElementById('save-sync-time-btn').addEventListener('click', updateSyncTime);
             
             // Update credentials button
-            document.getElementById('update-credentials-btn').addEventListener('click', () => {
+            document.getElementById('update-credentials-btn').addEventListener('click', async () => {
+                if (!currentCredentials) {
+                    currentCredentials = await fetchCredentials();
+                }
+                document.getElementById('readwise_token').value = currentCredentials?.readwise_token || '';
+                document.getElementById('twos_user_id').value = currentCredentials?.twos_user_id || '';
+                document.getElementById('twos_token').value = currentCredentials?.twos_token || '';
+                document.getElementById('capacities_space_id').value = currentCredentials?.capacities_space_id || '';
+                document.getElementById('capacities_token').value = currentCredentials?.capacities_token || '';
+                document.getElementById('enable_twos').checked = Boolean(currentCredentials?.twos_user_id && currentCredentials?.twos_token);
+                document.getElementById('enable_capacities').checked = Boolean(currentCredentials?.capacities_space_id && currentCredentials?.capacities_token);
+                toggleTwosFields();
+                toggleCapacitiesFields();
                 const modal = new bootstrap.Modal(document.getElementById('update-credentials-modal'));
                 modal.show();
             });
-            
+
+            document.getElementById('enable_twos').addEventListener('change', toggleTwosFields);
+            document.getElementById('enable_capacities').addEventListener('change', toggleCapacitiesFields);
+
             // Save credentials button
             document.getElementById('save-credentials-btn').addEventListener('click', updateCredentials);
             
@@ -971,6 +1041,8 @@
                 e.preventDefault();
                 logout();
             });
+            toggleTwosFields();
+            toggleCapacitiesFields();
         });
     </script>
 </body>

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -35,6 +35,28 @@ class TestSyncFunctionality:
             assert creds is not None
             assert creds.twos_user_id == 'test_twos_user'
             assert creds.capacities_space_id == 'space123'
+
+    def test_update_credentials_capacities_only(self, app, client, auth_headers):
+        """Test updating credentials when only Capacities is enabled."""
+        headers, user_id = auth_headers
+
+        with app.app_context():
+            response = client.post('/api/credentials',
+                headers=headers,
+                json={
+                    'readwise_token': 'rw_token',
+                    'twos_user_id': None,
+                    'twos_token': None,
+                    'capacities_space_id': 'space123',
+                    'capacities_token': 'cap_token'
+                }
+            )
+            assert response.status_code == 200
+
+            creds = ApiCredential.query.filter_by(user_id=user_id).first()
+            assert creds is not None
+            assert creds.twos_user_id is None
+            assert creds.capacities_space_id == 'space123'
     
     def test_get_credentials(self, app, client, auth_headers):
         """Test retrieving API credentials."""


### PR DESCRIPTION
## Summary
- allow Twos/Capacities sync to be configured independently
- mask and prefill API tokens in dashboard
- handle migrations and optional Twos columns

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_b_68989ba6df9c8332b068455948789da7